### PR TITLE
Fixes password persistence (and ip/name consistency) by syncing setters into __data, the serialized source for config.json.

### DIFF
--- a/resources/kroomba/irobot/configs.py
+++ b/resources/kroomba/irobot/configs.py
@@ -36,22 +36,30 @@ class iRobotConfig(object):
     @password.setter
     def password(self, value):
         self.__password = value
+        if value is None:
+            self.__data.pop("password", None)
+        else:
+            self.__data["password"] = value
 
     @property
     def ip(self):
         return self.__ip
 
+
     @ip.setter
     def ip(self, value):
         self.__ip = value
+        self.__data["ip"] = value
 
     @property
     def name(self):
         return self.__name
 
     @name.setter
-    def name(self, value: str):
+    def name(self, value):
         self.__name = value
+        # selon convention: robotname dans ton JSON
+        self.__data["robotname"] = value
 
     @property
     def version(self):

--- a/resources/kroomba/irobot/configs.py
+++ b/resources/kroomba/irobot/configs.py
@@ -107,9 +107,14 @@ class iRobotConfigs:
             configs = json.loads(self.__json_file.read_text(encoding='utf-8'))
             for blid, data in configs.items():
                 config = iRobotConfig(blid, data)
-                if config.password is None or len(config.password) <= 7:
-                    self._logger.warning("Robot %s at IP %s does not have a valid password configured, please run discovery to update the configuration", config.name, config.ip)
+                if config.password is None:
+                    self._logger.warning("Robot %s at IP %s does not have a password configured, please run discovery to update the configuration", config.name, config.ip)
                     continue
+                
+                if config.password is None or len(config.password) <= 7:
+                    self._logger.warning("Robot %s at IP %s does not have a valid password configured %s, please run discovery to update the configuration", config.name, config.ip, config.password)
+                    continue
+                
                 self.__robots[blid] = iRobotConfig(blid, data)
 
     def __save_config_file(self):


### PR DESCRIPTION
Context: after retrieving the robot password (cloud/robot), the daemon could connect in-memory, but after restart password became None because it was never written to config.json.
The configuration file is generated from __data via toJSON(), while setters previously updated only internal attributes.
Changes:
- Sync password, ip, and name setters with the internal __data dictionary
- password is now persisted into config.json (and removed from JSON when set to None)
- ip and robotname remain consistent between runtime object state and persisted config

Impact:

- Password is no longer lost after restart
- Prevents the “does not have a valid password configured…” warning once discovery populated the credentials